### PR TITLE
Updates package.json to use npm over yarn

### DIFF
--- a/packages/jest-sarif/package.json
+++ b/packages/jest-sarif/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "build": "tsc --build",
-    "prepare": "yarn build",
+    "prepare": "npm run build",
     "test": "jest"
   },
   "repository": {

--- a/packages/sarif-builder/package.json
+++ b/packages/sarif-builder/package.json
@@ -9,7 +9,7 @@
   "license": "MIT",
   "scripts": {
     "build": "tsc --build",
-    "prepare": "yarn build",
+    "prepare": "npm run build",
     "test": "jest --passWithNoTests"
   },
   "engines": {


### PR DESCRIPTION
Through force of habit, I incorrectly used `yarn` over `npm` in the prepare scripts in the sub-packages. This updates to use npm.