### PR TITLE
Fixes public exports to ensure types are correctly accessible

### DIFF
--- a/packages/jest-sarif/README.md
+++ b/packages/jest-sarif/README.md
@@ -34,6 +34,8 @@ You can import and use the matchers in one of two ways:
    require('@microsoft/jest-sarif');
    ```
 
+   If you're using TypeScript, you'll want to make your setup file a `.ts` file, and use `import '@microsoft/jest-sarif';` to ensure the type extensions are included.
+
 2. Including one of the following at the top of your test file
 
    ```ts
@@ -98,7 +100,7 @@ it('validates my SARIF result', () => {
 });
 ```
 
-### Typescript
+### TypeScript Definitions
 
 When using typescript in addition to the `buildMatcher` function, the dynamic matchers you build will not immediately be recognized by Jest's matcher types. To resolve this, you can add a one-time definition in a local types file that declares these additional matchers. Using the above `toMatchSarifResult` example, you'd add the following type extension to Jest's Matchers:
 

--- a/packages/jest-sarif/index.js
+++ b/packages/jest-sarif/index.js
@@ -1,1 +1,0 @@
-require('./lib/index');

--- a/packages/jest-sarif/package.json
+++ b/packages/jest-sarif/package.json
@@ -2,7 +2,8 @@
   "name": "@microsoft/jest-sarif",
   "version": "0.0.1",
   "description": "A collection of jest matchers for working with SARIF",
-  "main": "index.js",
+  "main": "lib/index.js",
+  "typings": "lib/index.d.ts",
   "scripts": {
     "build": "tsc --build",
     "prepare": "npm run build",

--- a/packages/jest-sarif/src/matchers/to-match-sarif-log.ts
+++ b/packages/jest-sarif/src/matchers/to-match-sarif-log.ts
@@ -7,7 +7,7 @@ declare global {
   namespace jest {
     interface Matchers<R, T> {
       /**
-       * Asserts that ${value} is an valid SARIF log.
+       * Asserts that actual value is an valid SARIF log.
        * @example
        * expect(value).toMatchSarifLog();
        */
@@ -15,7 +15,7 @@ declare global {
     }
     interface Expect {
       /**
-       * Asserts that ${value} is an `Array` containing only `Boolean` values.
+       * Asserts that actual value is an `Array` containing only `Boolean` values.
        * @example
        * expect(value).toEqual(
        *   expect.toMatchSarifLog()


### PR DESCRIPTION
Changes `index.js` export in favor of pointing to the built `lib/index` file. Also updates the typings reference to ensure correct type resolution. 

The documentation was additionally updated to ensure the instructions are accurate for those wanting to use `ts-jest`-style testing.