### PR TITLE
Updates jest-sarif build to include SARIF schema file in output

### DIFF
--- a/packages/jest-sarif/tsconfig.json
+++ b/packages/jest-sarif/tsconfig.json
@@ -6,5 +6,5 @@
     "esModuleInterop": true,
     "resolveJsonModule": true
   },
-  "include": ["./src"]
+  "include": ["./src", "./src/schemas/**/*.json"]
 }


### PR DESCRIPTION
The build was not including the SARIF schema JSON file. This PR adds it to the tsconfig.json.