### PR TITLE
Updates jsdoc with correct method name

### DIFF
--- a/packages/jest-sarif/src/matchers/to-be-valid-sarif-for.ts
+++ b/packages/jest-sarif/src/matchers/to-be-valid-sarif-for.ts
@@ -5,18 +5,18 @@ declare global {
   namespace jest {
     interface Matchers<R> {
       /**
-       * Asserts that actual value matches a valid SARIF @type {Sarif.Log}.
+       * Asserts that actual value matches a valid SARIF @type {Definition}.
        * @example
-       * expect(value).toBeValidSarifLog();
+       * expect(value).toBeValidSarifFor();
        */
       toBeValidSarifFor(definition: Definition): R;
     }
     interface Expect {
       /**
-       * Asserts that actual value matches a valid SARIF @type {Sarif.Log}.
+       * Asserts that actual value matches a valid SARIF @type {Definition}.
        * @example
        * expect(value).toEqual(
-       *   expect.toBeValidSarifLog()
+       *   expect.toBeValidSarifFor()
        * );
        */
       toBeValidSarifFor<T>(definition: Definition): jest.JestMatchers<T>;


### PR DESCRIPTION
Fixes incorrect jsdoc references in `toBeValidSarifFor`.