### PR TITLE
Adding publishConfig.access to package.json of sub-packages

### DIFF
--- a/packages/jest-sarif/package.json
+++ b/packages/jest-sarif/package.json
@@ -28,6 +28,9 @@
   ],
   "author": "Microsoft Corporation",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "bugs": {
     "url": "https://github.com/microsoft/sarif-js-sdk/issues"
   },

--- a/packages/sarif-builder/package.json
+++ b/packages/sarif-builder/package.json
@@ -7,6 +7,9 @@
   "repository": "https://github.com/microsoft/sarif-js-sdk",
   "author": "Microsoft Corporation",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "tsc --build",
     "prepare": "npm run build",


### PR DESCRIPTION
Allows `release-it` to release correctly.