### PR TITLE
Adding tslib to dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "sarif-js-sdk",
-  "version": "0.0.1",
+  "version": "1.0.0-beta.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.0.1",
+      "version": "1.0.0-beta.0",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -10832,12 +10832,13 @@
     },
     "packages/jest-sarif": {
       "name": "@microsoft/jest-sarif",
-      "version": "0.0.1",
+      "version": "1.0.0-beta.0",
       "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.6",
         "chalk": "^4.1.0",
-        "sync-fetch": "^0.3.0"
+        "sync-fetch": "^0.3.0",
+        "tslib": "^2.2.0"
       },
       "devDependencies": {
         "prettier": "^2.2.1"
@@ -10846,9 +10847,14 @@
         "node": ">= 12.11.*"
       }
     },
+    "packages/jest-sarif/node_modules/tslib": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+      "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+    },
     "packages/sarif-builder": {
       "name": "@microsoft/sarif-builder",
-      "version": "0.0.1",
+      "version": "1.0.0-beta.0",
       "license": "MIT",
       "engines": {
         "node": ">= 12.11.*"
@@ -11621,7 +11627,15 @@
         "ajv": "^6.12.6",
         "chalk": "^4.1.0",
         "prettier": "^2.2.1",
-        "sync-fetch": "^0.3.0"
+        "sync-fetch": "^0.3.0",
+        "tslib": "^2.2.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+        }
       }
     },
     "@microsoft/sarif-builder": {

--- a/packages/jest-sarif/package-lock.json
+++ b/packages/jest-sarif/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "@microsoft/jest-sarif",
+  "version": "1.0.0-beta.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "tslib": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+      "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+    }
+  }
+}

--- a/packages/jest-sarif/package.json
+++ b/packages/jest-sarif/package.json
@@ -38,7 +38,8 @@
   "dependencies": {
     "ajv": "^6.12.6",
     "chalk": "^4.1.0",
-    "sync-fetch": "^0.3.0"
+    "sync-fetch": "^0.3.0",
+    "tslib": "^2.2.0"
   },
   "devDependencies": {
     "prettier": "^2.2.1"


### PR DESCRIPTION
The compiled output depends on `tslib`, and when not present this generates an error (expectedly!). This fix adds `tslib` to `jest-sarif`'s dependencies.