### PR TITLE
Add no rule metadata test case to sarif-test and fix that test failure.

### DIFF
--- a/packages/eslint-formatter-sarif/__tests__/sarif-test.js
+++ b/packages/eslint-formatter-sarif/__tests__/sarif-test.js
@@ -43,8 +43,7 @@ const rules = {
     },
   },
   'fake/no-missing-meta': {
-    message:
-      'This rule is fake, and we expect it to have no docs',
+    message: 'This rule is fake, and we expect it to have no docs',
   },
 };
 

--- a/packages/eslint-formatter-sarif/__tests__/sarif-test.js
+++ b/packages/eslint-formatter-sarif/__tests__/sarif-test.js
@@ -42,6 +42,10 @@ const rules = {
       unexpected: 'Unnecessary semicolon.',
     },
   },
+  'ember-best-practices/no-lifecycle-events': {
+    message:
+      'Do not use events for lifecycle hooks. Please use the actual hooks instead: https://github.com/ember-best-practices/eslint-plugin-ember-best-practices/blob/master/guides/rules/no-lifecycle-events.md',
+  },
 };
 
 const sourceFilePath1 = 'service.js';
@@ -675,6 +679,34 @@ describe('formatter:sarif', () => {
         log.runs[0].results[0].locations[0].physicalLocation.region.startColumn
       ).not.toBeDefined();
       expect(log.runs[0].results[0].locations[0].physicalLocation.region.snippet).not.toBeDefined();
+    });
+  });
+
+  describe('when passed rules without metadata', () => {
+    const ruleid = 'ember-best-practices/no-lifecycle-events';
+    const code = [
+      {
+        filePath: sourceFilePath1,
+        messages: [
+          {
+            message: 'Unexpected value.',
+            ruleId: ruleid,
+            source: 'getValue()',
+          },
+        ],
+      },
+    ];
+
+    it('should return a log with one rule', () => {
+      const log = JSON.parse(formatter(code, { rulesMeta: rules }));
+
+      expect(log.runs[0].tool.driver.rules).toHaveLength(1);
+      expect(log.runs[0].tool.driver.rules[0].id).toBe(ruleid);
+      expect(log.runs[0].tool.driver.rules[0].shortDescription.text).toBe(
+        'No description provided'
+      );
+      expect(log.runs[0].tool.driver.rules[0].helpUri).toBe('Please see details in message');
+      expect(log.runs[0].tool.driver.rules[0].properties.category).toBe('No category provided');
     });
   });
 });

--- a/packages/eslint-formatter-sarif/__tests__/sarif-test.js
+++ b/packages/eslint-formatter-sarif/__tests__/sarif-test.js
@@ -42,9 +42,9 @@ const rules = {
       unexpected: 'Unnecessary semicolon.',
     },
   },
-  'ember-best-practices/no-lifecycle-events': {
+  'fake/no-missing-meta': {
     message:
-      'Do not use events for lifecycle hooks. Please use the actual hooks instead: https://github.com/ember-best-practices/eslint-plugin-ember-best-practices/blob/master/guides/rules/no-lifecycle-events.md',
+      'This rule is fake, and we expect it to have no docs',
   },
 };
 

--- a/packages/eslint-formatter-sarif/__tests__/sarif-test.js
+++ b/packages/eslint-formatter-sarif/__tests__/sarif-test.js
@@ -690,7 +690,7 @@ describe('formatter:sarif', () => {
         messages: [
           {
             message: 'Unexpected value.',
-            ruleId: ruleid,
+            ruleId: ruleId,
             source: 'getValue()',
           },
         ],
@@ -701,10 +701,7 @@ describe('formatter:sarif', () => {
       const log = JSON.parse(formatter(code, { rulesMeta: rules }));
 
       expect(log.runs[0].tool.driver.rules).toHaveLength(1);
-      expect(log.runs[0].tool.driver.rules[0].id).toBe(ruleid);
-      expect(log.runs[0].tool.driver.rules[0].shortDescription.text).toBe(
-        'No description provided'
-      );
+      expect(log.runs[0].tool.driver.rules[0].id).toBe(ruleId);
       expect(log.runs[0].tool.driver.rules[0].helpUri).toBe('Please see details in message');
       expect(log.runs[0].tool.driver.rules[0].properties.category).toBe('No category provided');
     });

--- a/packages/eslint-formatter-sarif/__tests__/sarif-test.js
+++ b/packages/eslint-formatter-sarif/__tests__/sarif-test.js
@@ -683,7 +683,7 @@ describe('formatter:sarif', () => {
   });
 
   describe('when passed rules without metadata', () => {
-    const ruleid = 'ember-best-practices/no-lifecycle-events';
+    const ruleId = 'fake/no-missing-meta';
     const code = [
       {
         filePath: sourceFilePath1,

--- a/packages/eslint-formatter-sarif/sarif.js
+++ b/packages/eslint-formatter-sarif/sarif.js
@@ -157,17 +157,31 @@ module.exports = function (results, data) {
               if (meta) {
                 sarifRuleIndices[message.ruleId] = nextRuleIndex++;
 
-                // Create a new entry in the rules dictionary.
-                sarifRules[message.ruleId] = {
-                  id: message.ruleId,
-                  helpUri: meta.docs.url,
-                  properties: {
-                    category: meta.docs.category,
-                  },
-                };
-                if (meta.docs.description) {
-                  sarifRules[message.ruleId].shortDescription = {
-                    text: meta.docs.description,
+                if (meta.docs) {
+                  // Create a new entry in the rules dictionary.
+                  sarifRules[message.ruleId] = {
+                    id: message.ruleId,
+                    helpUri: meta.docs.url,
+                    properties: {
+                      category: meta.docs.category,
+                    },
+                  };
+                  if (meta.docs.description) {
+                    sarifRules[message.ruleId].shortDescription = {
+                      text: meta.docs.description,
+                    };
+                  }
+                  // Some rulesMetas do not have docs property
+                } else {
+                  sarifRules[message.ruleId] = {
+                    id: message.ruleId,
+                    helpUri: 'Please see details in message',
+                    properties: {
+                      category: 'No category provided',
+                    },
+                    shortDescription: {
+                      text: 'No description provided',
+                    },
                   };
                 }
               }

--- a/packages/eslint-formatter-sarif/sarif.js
+++ b/packages/eslint-formatter-sarif/sarif.js
@@ -179,9 +179,6 @@ module.exports = function (results, data) {
                     properties: {
                       category: 'No category provided',
                     },
-                    shortDescription: {
-                      text: 'No description provided',
-                    },
                   };
                 }
               }


### PR DESCRIPTION
## Summary
Add a no metadata rule test case that mentioned in Issue #26 and fix it.

## Test
Npm test done.
```shell
 PASS  __tests__/sarif-test.js
  formatter:sarif
    when run
      ✓ should return a log with correct SARIF version and tool metadata (143 ms)
    when eslint version is known
      ✓ should return correct eslint version
    when passed no messages
      ✓ should return a log with files, but no results (1 ms)
    when passed one message
      ✓ should return a log with one file and one result (1 ms)
    when passed one message with a rule id
      ✓ should return a log with one rule (1 ms)
    when passed one message with line but no column nor source string
      ✓ should return a log with one result whose location region has only a startLine (4 ms)
    when passed one message with line and invalid column
      ✓ should return a log with one result whose location contains a region with line # and no column #
    when passed one message with line and column but no source string
      ✓ should return a log with one result whose location contains a region with line and column #s (1 ms)
    when passed one message with line, column, and source string
      ✓ should return a log with one result whose location contains a region with line and column #s
    when passed one message with a source string but without line and column #s
      ✓ should return a log with one result whose location contains a region with line and column #s (1 ms)
    when passed two results with two messages each
      ✓ should return a log with two files, three rules, and four results (3 ms)
    when passed two results with one having no message and one with two messages
      ✓ should return a log with two files, two rules, and two results (2 ms)
    when passed a result with no rule id
      ✓ should return a log with no rules, no results, and a tool execution notification (1 ms)
    when passed a rule with no description
      ✓ should return a log with one file, one rule, and one result (1 ms)
    when passed rules without metadata
      ✓ should return a log with one rule

Test Suites: 1 passed, 1 total
Tests:       15 passed, 15 total
Snapshots:   0 total
Time:        2.171 s
Ran all test suites.
```