### PR TITLE
Fix test failure when dependabot try to bumps semver-regex from 3.1.2 to 3.1.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9615,9 +9615,9 @@
       }
     },
     "node_modules/semver-regex": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-3.1.2.tgz",
-      "integrity": "sha512-bXWyL6EAKOJa81XG1OZ/Yyuq+oT0b2YLlxx7c+mrdYPaPbnj6WgVULXhinMIeZGufuUBu/eVRqXEhiv4imfwxA==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-3.1.3.tgz",
+      "integrity": "sha512-Aqi54Mk9uYTjVexLnR67rTyBusmwd04cLkHy9hNvk3+G3nT2Oyg7E0l4XVbOaNwIvQ3hHeYxGcyEy+mKreyBFQ==",
       "dev": true,
       "engines": {
         "node": ">=8"
@@ -11414,13 +11414,13 @@
       "version": "2.1.5",
       "license": "MIT",
       "dependencies": {
-        "jschardet": "latest",
+        "jschardet": "*",
         "lodash": "^4.17.14",
         "utf8": "^3.0.0"
       },
       "devDependencies": {
         "rewire": "^5.0.0",
-        "semver-regex": "^3.1.2"
+        "semver-regex": "^3.1.3"
       },
       "engines": {
         "node": ">= 12.11.*"
@@ -12218,10 +12218,10 @@
     "@microsoft/eslint-formatter-sarif": {
       "version": "file:packages/eslint-formatter-sarif",
       "requires": {
-        "jschardet": "latest",
+        "jschardet": "*",
         "lodash": "^4.17.14",
         "rewire": "^5.0.0",
-        "semver-regex": "^3.1.2",
+        "semver-regex": "^3.1.3",
         "utf8": "^3.0.0"
       }
     },
@@ -19234,9 +19234,9 @@
       }
     },
     "semver-regex": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-3.1.2.tgz",
-      "integrity": "sha512-bXWyL6EAKOJa81XG1OZ/Yyuq+oT0b2YLlxx7c+mrdYPaPbnj6WgVULXhinMIeZGufuUBu/eVRqXEhiv4imfwxA==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-3.1.3.tgz",
+      "integrity": "sha512-Aqi54Mk9uYTjVexLnR67rTyBusmwd04cLkHy9hNvk3+G3nT2Oyg7E0l4XVbOaNwIvQ3hHeYxGcyEy+mKreyBFQ==",
       "dev": true
     },
     "set-blocking": {

--- a/packages/eslint-formatter-sarif/package-lock.json
+++ b/packages/eslint-formatter-sarif/package-lock.json
@@ -1187,9 +1187,9 @@
       }
     },
     "node_modules/semver-regex": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-3.1.2.tgz",
-      "integrity": "sha512-bXWyL6EAKOJa81XG1OZ/Yyuq+oT0b2YLlxx7c+mrdYPaPbnj6WgVULXhinMIeZGufuUBu/eVRqXEhiv4imfwxA==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-3.1.3.tgz",
+      "integrity": "sha512-Aqi54Mk9uYTjVexLnR67rTyBusmwd04cLkHy9hNvk3+G3nT2Oyg7E0l4XVbOaNwIvQ3hHeYxGcyEy+mKreyBFQ==",
       "dev": true,
       "engines": {
         "node": ">=8"
@@ -2347,9 +2347,9 @@
       "dev": true
     },
     "semver-regex": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-3.1.2.tgz",
-      "integrity": "sha512-bXWyL6EAKOJa81XG1OZ/Yyuq+oT0b2YLlxx7c+mrdYPaPbnj6WgVULXhinMIeZGufuUBu/eVRqXEhiv4imfwxA==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-3.1.3.tgz",
+      "integrity": "sha512-Aqi54Mk9uYTjVexLnR67rTyBusmwd04cLkHy9hNvk3+G3nT2Oyg7E0l4XVbOaNwIvQ3hHeYxGcyEy+mKreyBFQ==",
       "dev": true
     },
     "shebang-command": {

--- a/packages/eslint-formatter-sarif/package.json
+++ b/packages/eslint-formatter-sarif/package.json
@@ -41,6 +41,6 @@
   },
   "devDependencies": {
     "rewire": "^5.0.0",
-    "semver-regex": "^3.1.2"
+    "semver-regex": "^3.1.3"
   }
 }

--- a/packages/jest-sarif/__tests__/matchers/to-be-valid-sarif-definitions-test.ts
+++ b/packages/jest-sarif/__tests__/matchers/to-be-valid-sarif-definitions-test.ts
@@ -66,7 +66,7 @@ describe('toBeValidSarifResult', () => {
     const testObj = { another: 'property' };
     try {
       expect(testObj).toBeValidSarifFor('result');
-    } catch (error) {
+    } catch (error: any) {
       // eslint-disable-next-line jest/no-try-expect, jest/no-conditional-expect
       expect(error.matcherResult).toEqual({
         actual: testObj,

--- a/packages/jest-sarif/__tests__/matchers/to-be-valid-sarif-log-test.ts
+++ b/packages/jest-sarif/__tests__/matchers/to-be-valid-sarif-log-test.ts
@@ -47,7 +47,7 @@ describe('toBeValidSarifLog', () => {
     const testObj = { another: 'property' };
     try {
       expect(testObj).toBeValidSarifLog();
-    } catch (error) {
+    } catch (error: any) {
       // eslint-disable-next-line jest/no-try-expect, jest/no-conditional-expect
       expect(error.matcherResult).toEqual({
         actual: testObj,


### PR DESCRIPTION
Fix test failure when dependabot try to bumps semver-regex from 3.1.2 to 3.1.3:
https://github.com/microsoft/sarif-js-sdk/pull/28
https://github.com/microsoft/sarif-js-sdk/pull/29

Included the 2 dependabot PR in this PR just to make sure new test code is run with and can pass with them.