### PR TITLE
Update release-it as prerequisite for Dependabot update shelljs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "eslint-plugin-unicorn": "^29.0.0",
         "jest": "^26.6.3",
         "prettier": "^2.2.1",
-        "release-it": "^14.2.1",
+        "release-it": "^14.14.2",
         "release-it-lerna-changelog": "^3.1.0",
         "release-it-yarn-workspaces": "^2.0.1",
         "ts-jest": "^26.5.4",
@@ -8208,39 +8208,41 @@
       }
     },
     "node_modules/release-it": {
-      "version": "14.5.0",
-      "resolved": "https://registry.npmjs.org/release-it/-/release-it-14.5.0.tgz",
-      "integrity": "sha512-3xwKx3B5i4TVMlCZsNXOCc/S3iviQmi64FJExsvMg5ZjlbBsEYF4qbPLVMq308i7MeDWhubiFHIb3XYuh8pt6Q==",
+      "version": "14.14.2",
+      "resolved": "https://registry.npmjs.org/release-it/-/release-it-14.14.2.tgz",
+      "integrity": "sha512-+TE5Zg7x5BE/xw6i8SN9rmsGxCE2GVqH1v8Ay1L09nsLQx1HJhihAqUtCCDdgOuLvGpX0xgDMsSzakDlDLpOkA==",
       "dev": true,
       "dependencies": {
         "@iarna/toml": "2.2.5",
-        "@octokit/rest": "18.3.5",
-        "async-retry": "1.3.1",
-        "chalk": "4.1.0",
-        "cosmiconfig": "7.0.0",
-        "debug": "4.3.1",
-        "deprecated-obj": "2.0.0",
-        "execa": "5.0.0",
-        "find-up": "5.0.0",
+        "@octokit/rest": "18.12.0",
+        "async-retry": "1.3.3",
+        "chalk": "4.1.2",
+        "cosmiconfig": "7.0.1",
+        "debug": "4.3.4",
+        "execa": "5.1.1",
         "form-data": "4.0.0",
-        "git-url-parse": "11.4.4",
-        "globby": "11.0.2",
-        "got": "11.8.2",
+        "git-url-parse": "11.6.0",
+        "globby": "11.0.4",
+        "got": "9.6.0",
         "import-cwd": "3.0.0",
-        "inquirer": "8.0.0",
-        "is-ci": "3.0.0",
+        "inquirer": "8.2.0",
+        "is-ci": "3.0.1",
         "lodash": "4.17.21",
-        "mime-types": "2.1.29",
-        "ora": "5.4.0",
-        "os-name": "4.0.0",
+        "mime-types": "2.1.35",
+        "new-github-release-url": "1.0.0",
+        "open": "7.4.2",
+        "ora": "5.4.1",
+        "os-name": "4.0.1",
         "parse-json": "5.2.0",
-        "semver": "7.3.4",
-        "shelljs": "0.8.4",
+        "promise.allsettled": "1.0.5",
+        "semver": "7.3.5",
+        "shelljs": "0.8.5",
         "update-notifier": "5.1.0",
         "url-join": "4.0.1",
         "uuid": "8.3.2",
+        "wildcard-match": "5.1.2",
         "yaml": "1.10.2",
-        "yargs-parser": "20.2.7"
+        "yargs-parser": "20.2.9"
       },
       "bin": {
         "release-it": "bin/release-it.js"
@@ -8376,9 +8378,9 @@
       }
     },
     "node_modules/release-it/node_modules/execa": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-5.0.0.tgz",
-      "integrity": "sha512-ov6w/2LCiuyO4RLYGdpFGjkcs0wMTgGE8PrkTHikeUy5iJekXyPIKUjifk5CsE0pt7sMCrMZ3YNqoCj6idQOnQ==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
       "dev": true,
       "dependencies": {
         "cross-spawn": "^7.0.3",
@@ -8415,9 +8417,9 @@
       }
     },
     "node_modules/release-it/node_modules/get-stream": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.0.tgz",
-      "integrity": "sha512-A1B3Bh1UmL0bidM/YX2NsCOTnGJePL9rO/M+Mw3m9f2gUpfokS0hi5Eah0WSUEWZdZhIZtMjkIYS7mDfOqNHbg==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
       "dev": true,
       "engines": {
         "node": ">=10"
@@ -8436,21 +8438,21 @@
       }
     },
     "node_modules/release-it/node_modules/is-ci": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.0.tgz",
-      "integrity": "sha512-kDXyttuLeslKAHYL/K28F2YkM3x5jvFPEw3yXbRptXydjD9rpLEz+C5K5iutY9ZiUu6AP41JdvRQwF4Iqs4ZCQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.1.tgz",
+      "integrity": "sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==",
       "dev": true,
       "dependencies": {
-        "ci-info": "^3.1.1"
+        "ci-info": "^3.2.0"
       },
       "bin": {
         "is-ci": "bin.js"
       }
     },
     "node_modules/release-it/node_modules/is-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-      "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
       "dev": true,
       "engines": {
         "node": ">=8"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "eslint-plugin-unicorn": "^29.0.0",
     "jest": "^26.6.3",
     "prettier": "^2.2.1",
-    "release-it": "^14.2.1",
+    "release-it": "^14.14.2",
     "release-it-lerna-changelog": "^3.1.0",
     "release-it-yarn-workspaces": "^2.0.1",
     "ts-jest": "^26.5.4",


### PR DESCRIPTION
shelljs has security issue and Dependabot try to update it but failed, because the release-it is outdated.
This changeset only updates release-it so that Dependabot can process with the auto update, verified in fork.