### PR TITLE
Updates lockfile using Volta-specified version of npm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "sarif-js-sdk",
       "version": "1.0.0-beta.1",
       "license": "MIT",
       "workspaces": [
@@ -11259,7 +11260,7 @@
       "license": "MIT",
       "dependencies": {
         "eslint": "^8.9.0",
-        "jschardet": "*",
+        "jschardet": "latest",
         "lodash": "^4.17.14",
         "utf8": "^3.0.0"
       },
@@ -12269,7 +12270,7 @@
       "version": "file:packages/eslint-formatter-sarif",
       "requires": {
         "eslint": "^8.9.0",
-        "jschardet": "*",
+        "jschardet": "latest",
         "lodash": "^4.17.14",
         "rewire": "^6.0.0",
         "semver-regex": "^3.1.3",
@@ -16816,14 +16817,14 @@
       }
     },
     "jsprim": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
       "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
+        "json-schema": "0.4.0",
         "verror": "1.10.0"
       }
     },


### PR DESCRIPTION
This repository uses [Volta](https://volta.sh/) to manage versions of the toolchain when working in it. This helps us ensure that when we run tools like npm and node that we're all using the same versions. `npm` in particular will generate differences in the lock file when you're not on the same version.

This PR runs `npm` with the correct version via Volta, and updates the lockfile.