### PR TITLE
Update release-it setup to each package vs monorepo

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ JavaScript code and supporting files for working with the 'Static Analysis Resul
 | [@microsoft/sarif-builder][@microsoft/sarif-builder] | [![Version](https://img.shields.io/npm/v/@microsoft/sarif-builder.svg)](https://npmjs.org/package/@microsoft/sarif-builder) | A builder library for authoring [SARIF][sarif] logs. |
 | [@microsoft/eslint-formatter-sarif][@microsoft/eslint-formatter-sarif] | [![Version](https://img.shields.io/npm/v/@microsoft/eslint-formatter-sarif.svg)](https://npmjs.org/package/@microsoft/eslint-formatter-sarif) | A formatter for ESLint that produces output in the [SARIF][sarif] logs. |
 
+## Development
+
+This project uses the Volta tool manager to manage the tool dependencies in this project. This allows us to maintain consistency when developing across contributors.
+
+The tool manager is available at [volta.sh](https://volta.sh/). Contributors should ensure this is installed before working in this project.
+
 ## Contributing
 
 This project welcomes contributions and suggestions. Most contributions require you to agree to a

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "sarif-js-sdk",
       "version": "1.0.0-beta.1",
       "license": "MIT",
       "workspaces": [
@@ -27,7 +28,6 @@
         "prettier": "^2.2.1",
         "release-it": "^14.14.2",
         "release-it-lerna-changelog": "^3.1.0",
-        "release-it-yarn-workspaces": "^2.0.1",
         "ts-jest": "^26.5.4",
         "typescript": "^4.2.3"
       }
@@ -1192,12 +1192,6 @@
       "dependencies": {
         "@types/unist": "*"
       }
-    },
-    "node_modules/@types/minimatch": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
-      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
-      "dev": true
     },
     "node_modules/@types/node": {
       "version": "14.14.42",
@@ -2929,15 +2923,6 @@
       "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
       "dev": true
     },
-    "node_modules/detect-indent": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.0.0.tgz",
-      "integrity": "sha512-oSyFlqaTHCItVRGK5RmrmjB+CmaMOW7IaNA/kdxqhoa6d17j/5ce9O9eWXmV/KEdRwqpQA+Vqe8a8Bsybu4YnA==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/detect-newline": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -3090,12 +3075,6 @@
       "engines": {
         "node": ">=8.6"
       }
-    },
-    "node_modules/ensure-posix-path": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ensure-posix-path/-/ensure-posix-path-1.1.1.tgz",
-      "integrity": "sha512-VWU0/zXzVbeJNXvME/5EmLuEj2TauvoaTz6aFYK1Z92JCBlDlZ3Gu0tuGR42kpW1754ywTs+QB0g5TP0oj9Zaw==",
-      "dev": true
     },
     "node_modules/err-code": {
       "version": "1.1.2",
@@ -6838,19 +6817,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/matcher-collection": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-2.0.1.tgz",
-      "integrity": "sha512-daE62nS2ZQsDg9raM0IlZzLmI2u+7ZapXBwdoeBUKAYERPDDIc0qNqA8E0Rp2D+gspKR7BgIFP52GeujaGXWeQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/minimatch": "^3.0.3",
-        "minimatch": "^3.0.2"
-      },
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
-      }
-    },
     "node_modules/mdast-util-from-markdown": {
       "version": "0.8.5",
       "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-0.8.5.tgz",
@@ -8587,26 +8553,6 @@
       },
       "engines": {
         "node": ">=8.17.0"
-      }
-    },
-    "node_modules/release-it-yarn-workspaces": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/release-it-yarn-workspaces/-/release-it-yarn-workspaces-2.0.1.tgz",
-      "integrity": "sha512-dLX/mnvKpwDNvfbRm+ji3NWxVIEFlSac+29y2KkhPORKYgxFPKawhRm9/ESZOdnLIy7bIwtB17MILGhwohzVgw==",
-      "dev": true,
-      "dependencies": {
-        "detect-indent": "^6.0.0",
-        "detect-newline": "^3.1.0",
-        "semver": "^7.1.3",
-        "url-join": "^4.0.1",
-        "validate-peer-dependencies": "^1.0.0",
-        "walk-sync": "^2.0.2"
-      },
-      "engines": {
-        "node": "10.* || 12.* || >= 14"
-      },
-      "peerDependencies": {
-        "release-it": "^14.0.0"
       }
     },
     "node_modules/release-it/node_modules/@sindresorhus/is": {
@@ -10872,21 +10818,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/walk-sync": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
-      "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
-      "dev": true,
-      "dependencies": {
-        "@types/minimatch": "^3.0.3",
-        "ensure-posix-path": "^1.1.0",
-        "matcher-collection": "^2.0.0",
-        "minimatch": "^3.0.4"
-      },
-      "engines": {
-        "node": "8.* || >= 10.*"
-      }
-    },
     "node_modules/walker": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
@@ -11259,7 +11190,7 @@
       "license": "MIT",
       "dependencies": {
         "eslint": "^8.9.0",
-        "jschardet": "*",
+        "jschardet": "latest",
         "lodash": "^4.17.14",
         "utf8": "^3.0.0"
       },
@@ -12269,7 +12200,7 @@
       "version": "file:packages/eslint-formatter-sarif",
       "requires": {
         "eslint": "^8.9.0",
-        "jschardet": "*",
+        "jschardet": "latest",
         "lodash": "^4.17.14",
         "rewire": "^6.0.0",
         "semver-regex": "^3.1.3",
@@ -12725,12 +12656,6 @@
       "requires": {
         "@types/unist": "*"
       }
-    },
-    "@types/minimatch": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
-      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
-      "dev": true
     },
     "@types/node": {
       "version": "14.14.42",
@@ -14101,12 +14026,6 @@
       "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
       "dev": true
     },
-    "detect-indent": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.0.0.tgz",
-      "integrity": "sha512-oSyFlqaTHCItVRGK5RmrmjB+CmaMOW7IaNA/kdxqhoa6d17j/5ce9O9eWXmV/KEdRwqpQA+Vqe8a8Bsybu4YnA==",
-      "dev": true
-    },
     "detect-newline": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -14233,12 +14152,6 @@
       "requires": {
         "ansi-colors": "^4.1.1"
       }
-    },
-    "ensure-posix-path": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ensure-posix-path/-/ensure-posix-path-1.1.1.tgz",
-      "integrity": "sha512-VWU0/zXzVbeJNXvME/5EmLuEj2TauvoaTz6aFYK1Z92JCBlDlZ3Gu0tuGR42kpW1754ywTs+QB0g5TP0oj9Zaw==",
-      "dev": true
     },
     "err-code": {
       "version": "1.1.2",
@@ -16816,14 +16729,14 @@
       }
     },
     "jsprim": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
       "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
+        "json-schema": "0.4.0",
         "verror": "1.10.0"
       }
     },
@@ -17182,16 +17095,6 @@
       "dev": true,
       "requires": {
         "object-visit": "^1.0.0"
-      }
-    },
-    "matcher-collection": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-2.0.1.tgz",
-      "integrity": "sha512-daE62nS2ZQsDg9raM0IlZzLmI2u+7ZapXBwdoeBUKAYERPDDIc0qNqA8E0Rp2D+gspKR7BgIFP52GeujaGXWeQ==",
-      "dev": true,
-      "requires": {
-        "@types/minimatch": "^3.0.3",
-        "minimatch": "^3.0.2"
       }
     },
     "mdast-util-from-markdown": {
@@ -18735,20 +18638,6 @@
             "rimraf": "^3.0.0"
           }
         }
-      }
-    },
-    "release-it-yarn-workspaces": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/release-it-yarn-workspaces/-/release-it-yarn-workspaces-2.0.1.tgz",
-      "integrity": "sha512-dLX/mnvKpwDNvfbRm+ji3NWxVIEFlSac+29y2KkhPORKYgxFPKawhRm9/ESZOdnLIy7bIwtB17MILGhwohzVgw==",
-      "dev": true,
-      "requires": {
-        "detect-indent": "^6.0.0",
-        "detect-newline": "^3.1.0",
-        "semver": "^7.1.3",
-        "url-join": "^4.0.1",
-        "validate-peer-dependencies": "^1.0.0",
-        "walk-sync": "^2.0.2"
       }
     },
     "remove-trailing-separator": {
@@ -20391,18 +20280,6 @@
       "dev": true,
       "requires": {
         "xml-name-validator": "^3.0.0"
-      }
-    },
-    "walk-sync": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
-      "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
-      "dev": true,
-      "requires": {
-        "@types/minimatch": "^3.0.3",
-        "ensure-posix-path": "^1.1.0",
-        "matcher-collection": "^2.0.0",
-        "minimatch": "^3.0.4"
       }
     },
     "walker": {

--- a/package.json
+++ b/package.json
@@ -35,29 +35,11 @@
     "prettier": "^2.2.1",
     "release-it": "^14.14.2",
     "release-it-lerna-changelog": "^3.1.0",
-    "release-it-yarn-workspaces": "^2.0.1",
     "ts-jest": "^26.5.4",
     "typescript": "^4.2.3"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"
-  },
-  "release-it": {
-    "plugins": {
-      "release-it-lerna-changelog": {
-        "infile": "CHANGELOG.md",
-        "launchEditor": true
-      },
-      "release-it-yarn-workspaces": true
-    },
-    "git": {
-      "tagName": "v${version}"
-    },
-    "github": {
-      "release": true,
-      "tokenRef": "GITHUB_AUTH"
-    },
-    "npm": false
   },
   "volta": {
     "node": "14.19.1",

--- a/packages/eslint-formatter-sarif/package.json
+++ b/packages/eslint-formatter-sarif/package.json
@@ -52,7 +52,7 @@
       }
     },
     "git": {
-      "tagName": "${name}@${version}"
+      "tagName": "eslint-formatter-sarif@${version}"
     },
     "github": {
       "release": true,

--- a/packages/eslint-formatter-sarif/package.json
+++ b/packages/eslint-formatter-sarif/package.json
@@ -43,5 +43,20 @@
   "devDependencies": {
     "rewire": "^6.0.0",
     "semver-regex": "^3.1.3"
+  },
+  "release-it": {
+    "plugins": {
+      "release-it-lerna-changelog": {
+        "infile": "CHANGELOG.md",
+        "launchEditor": true
+      }
+    },
+    "git": {
+      "tagName": "${name}@${version}"
+    },
+    "github": {
+      "release": true,
+      "tokenRef": "GITHUB_AUTH"
+    }
   }
 }

--- a/packages/jest-sarif/CHANGELOG.md
+++ b/packages/jest-sarif/CHANGELOG.md
@@ -1,39 +1,30 @@
 ## v1.0.0-beta.1 (2021-05-04)
 
 #### :rocket: Enhancement
-* `jest-sarif`
   * [#13](https://github.com/microsoft/sarif-js-sdk/pull/13) feat: Expanding API surface area by adding single matcher: toBeValidSarifFor(definition) ([@scalvert](https://github.com/scalvert))
 * `jest-sarif`, `sarif-builder`
   * [#9](https://github.com/microsoft/sarif-js-sdk/pull/9) Adds a new package: @microsoft/jest-sarif ([@scalvert](https://github.com/scalvert))
 
 #### :bug: Bug Fix
-* `jest-sarif`
   * [#21](https://github.com/microsoft/sarif-js-sdk/pull/21) Adding tslib to dependencies ([@scalvert](https://github.com/scalvert))
   * [#16](https://github.com/microsoft/sarif-js-sdk/pull/16) Updates jsdoc with correct method name ([@scalvert](https://github.com/scalvert))
   * [#15](https://github.com/microsoft/sarif-js-sdk/pull/15) Updates jest-sarif build to include SARIF schema file in output ([@scalvert](https://github.com/scalvert))
   * [#11](https://github.com/microsoft/sarif-js-sdk/pull/11) Fixes public exports to ensure types are correctly accessible ([@scalvert](https://github.com/scalvert))
 
 #### :memo: Documentation
-* `jest-sarif`, `sarif-builder`
   * [#20](https://github.com/microsoft/sarif-js-sdk/pull/20) Adding top-level readme with appropriate links. Adds badges to all readmes. ([@scalvert](https://github.com/scalvert))
-* `jest-sarif`
   * [#16](https://github.com/microsoft/sarif-js-sdk/pull/16) Updates jsdoc with correct method name ([@scalvert](https://github.com/scalvert))
 
 #### :house: Internal
-* `jest-sarif`, `sarif-builder`
   * [#19](https://github.com/microsoft/sarif-js-sdk/pull/19) Release 1.0.0-beta.0 ([@scalvert](https://github.com/scalvert))
   * [#18](https://github.com/microsoft/sarif-js-sdk/pull/18) Adding publishConfig.access to package.json of sub-packages ([@scalvert](https://github.com/scalvert))
   * [#10](https://github.com/microsoft/sarif-js-sdk/pull/10) Updates package.json to use npm over yarn ([@scalvert](https://github.com/scalvert))
-* Other
   * [#17](https://github.com/microsoft/sarif-js-sdk/pull/17) Updated release-it-yarn-workspaces ([@scalvert](https://github.com/scalvert))
   * [#2](https://github.com/microsoft/sarif-js-sdk/pull/2) Adding release-it configuration with workspaces publishing support ([@scalvert](https://github.com/scalvert))
   * [#8](https://github.com/microsoft/sarif-js-sdk/pull/8) Regenerates the lockfile to include specific package name ([@scalvert](https://github.com/scalvert))
   * [#4](https://github.com/microsoft/sarif-js-sdk/pull/4) Setup basic GitHub Actions CI ([@rwjblue](https://github.com/rwjblue))
   * [#1](https://github.com/microsoft/sarif-js-sdk/pull/1) Repository infrastructure setup ([@scalvert](https://github.com/scalvert))
-* `jest-sarif`
   * [#12](https://github.com/microsoft/sarif-js-sdk/pull/12) Adds badges to @microsoft/jest-sarif README ([@scalvert](https://github.com/scalvert))
-* `sarif-builder`
-  * [#6](https://github.com/microsoft/sarif-js-sdk/pull/6) Update .gitignore to ensure inclusion of package files ([@scalvert](https://github.com/scalvert))
 
 #### Committers: 3
 - Eddy Nakamura ([@eddynaka](https://github.com/eddynaka))
@@ -44,35 +35,27 @@
 ## v1.0.0-beta.0 (2021-04-27)
 
 #### :rocket: Enhancement
-* `jest-sarif`
   * [#13](https://github.com/microsoft/sarif-js-sdk/pull/13) feat: Expanding API surface area by adding single matcher: toBeValidSarifFor(definition) ([@scalvert](https://github.com/scalvert))
 * `jest-sarif`, `sarif-builder`
   * [#9](https://github.com/microsoft/sarif-js-sdk/pull/9) Adds a new package: @microsoft/jest-sarif ([@scalvert](https://github.com/scalvert))
 
 #### :bug: Bug Fix
-* `jest-sarif`
   * [#16](https://github.com/microsoft/sarif-js-sdk/pull/16) Updates jsdoc with correct method name ([@scalvert](https://github.com/scalvert))
   * [#15](https://github.com/microsoft/sarif-js-sdk/pull/15) Updates jest-sarif build to include SARIF schema file in output ([@scalvert](https://github.com/scalvert))
   * [#11](https://github.com/microsoft/sarif-js-sdk/pull/11) Fixes public exports to ensure types are correctly accessible ([@scalvert](https://github.com/scalvert))
 
 #### :memo: Documentation
-* `jest-sarif`
   * [#16](https://github.com/microsoft/sarif-js-sdk/pull/16) Updates jsdoc with correct method name ([@scalvert](https://github.com/scalvert))
 
 #### :house: Internal
-* `jest-sarif`, `sarif-builder`
   * [#18](https://github.com/microsoft/sarif-js-sdk/pull/18) Adding publishConfig.access to package.json of sub-packages ([@scalvert](https://github.com/scalvert))
   * [#10](https://github.com/microsoft/sarif-js-sdk/pull/10) Updates package.json to use npm over yarn ([@scalvert](https://github.com/scalvert))
-* Other
   * [#17](https://github.com/microsoft/sarif-js-sdk/pull/17) Updated release-it-yarn-workspaces ([@scalvert](https://github.com/scalvert))
   * [#2](https://github.com/microsoft/sarif-js-sdk/pull/2) Adding release-it configuration with workspaces publishing support ([@scalvert](https://github.com/scalvert))
   * [#8](https://github.com/microsoft/sarif-js-sdk/pull/8) Regenerates the lockfile to include specific package name ([@scalvert](https://github.com/scalvert))
   * [#4](https://github.com/microsoft/sarif-js-sdk/pull/4) Setup basic GitHub Actions CI ([@rwjblue](https://github.com/rwjblue))
   * [#1](https://github.com/microsoft/sarif-js-sdk/pull/1) Repository infrastructure setup ([@scalvert](https://github.com/scalvert))
-* `jest-sarif`
   * [#12](https://github.com/microsoft/sarif-js-sdk/pull/12) Adds badges to @microsoft/jest-sarif README ([@scalvert](https://github.com/scalvert))
-* `sarif-builder`
-  * [#6](https://github.com/microsoft/sarif-js-sdk/pull/6) Update .gitignore to ensure inclusion of package files ([@scalvert](https://github.com/scalvert))
 
 #### Committers: 3
 - Eddy Nakamura ([@eddynaka](https://github.com/eddynaka))

--- a/packages/jest-sarif/package.json
+++ b/packages/jest-sarif/package.json
@@ -52,7 +52,7 @@
       }
     },
     "git": {
-      "tagName": "${name}@${version}"
+      "tagName": "jest-sarif@${version}"
     },
     "github": {
       "release": true,

--- a/packages/jest-sarif/package.json
+++ b/packages/jest-sarif/package.json
@@ -43,5 +43,20 @@
   },
   "devDependencies": {
     "prettier": "^2.2.1"
+  },
+  "release-it": {
+    "plugins": {
+      "release-it-lerna-changelog": {
+        "infile": "CHANGELOG.md",
+        "launchEditor": true
+      }
+    },
+    "git": {
+      "tagName": "${name}@${version}"
+    },
+    "github": {
+      "release": true,
+      "tokenRef": "GITHUB_AUTH"
+    }
   }
 }

--- a/packages/sarif-builder/package.json
+++ b/packages/sarif-builder/package.json
@@ -26,7 +26,7 @@
       }
     },
     "git": {
-      "tagName": "${name}@${version}"
+      "tagName": "sarif-builder@${version}"
     },
     "github": {
       "release": true,

--- a/packages/sarif-builder/package.json
+++ b/packages/sarif-builder/package.json
@@ -17,5 +17,20 @@
   },
   "engines": {
     "node": ">= 14"
+  },
+  "release-it": {
+    "plugins": {
+      "release-it-lerna-changelog": {
+        "infile": "CHANGELOG.md",
+        "launchEditor": true
+      }
+    },
+    "git": {
+      "tagName": "${name}@${version}"
+    },
+    "github": {
+      "release": true,
+      "tokenRef": "GITHUB_AUTH"
+    }
   }
 }


### PR DESCRIPTION
Since this monorepo now houses the `eslint-formatter-sarif` in addition to `jest-sarif` and `sarif-builder`, it doesn't make as much sense to use the `release-it-yarn-workspaces` plugin, which requires each sub-package to be versioned the same.

This change pushes the release-it configuration down to the package level, and changes the tag format to follow the `<package-name>@1.2.3` convention, which allows for independent versioning while still benefiting from housing these packages together.