### PR TITLE
Resets root level version number

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sarif-js-sdk",
-  "version": "1.0.0-beta.1",
+  "version": "0.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "sarif-js-sdk",
-      "version": "1.0.0-beta.1",
+      "version": "0.0.0",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sarif-js-sdk",
-  "version": "1.0.0-beta.1",
+  "version": "0.0.0",
   "private": true,
   "description": "JavaScript code and supporting files for working with the 'Static Analysis Results Interchange Format' (SARIF, see oasis-tcs/sarif-spec)",
   "repository": "https://github.com/microsoft/sarif-js-sdk.git",


### PR DESCRIPTION
The root package doesn't need to have a version number in it, since we've not defaulted to each package managing their own publish step individually. This change resets to `0.0.0` to indicate that this number doesn't represent any actual package version.