### PR TITLE
feat(eslint-fomatter): add the option to ignore suppressed messages

### DIFF
--- a/packages/eslint-formatter-sarif/sarif.js
+++ b/packages/eslint-formatter-sarif/sarif.js
@@ -132,9 +132,10 @@ module.exports = function (results, data) {
 
       const containsSuppressedMessages =
         result.suppressedMessages && result.suppressedMessages.length > 0;
-      const messages = containsSuppressedMessages && !ignoreSuppressed
-        ? [...result.messages, ...result.suppressedMessages]
-        : result.messages;
+      const messages =
+        containsSuppressedMessages && !ignoreSuppressed
+          ? [...result.messages, ...result.suppressedMessages]
+          : result.messages;
 
       if (messages.length > 0) {
         for (const message of messages) {

--- a/packages/eslint-formatter-sarif/sarif.js
+++ b/packages/eslint-formatter-sarif/sarif.js
@@ -81,6 +81,7 @@ module.exports = function (results, data) {
   let nextRuleIndex = 0;
   const sarifResults = [];
   const embedFileContents = process.env.SARIF_ESLINT_EMBED === 'true';
+  const ignoreSuppressed = process.env.SARIF_ESLINT_IGNORE_SUPPRESSED === 'true';
 
   // Emit a tool configuration notification with this id if ESLint emits a message with
   // no ruleId (which indicates an internal error in ESLint).
@@ -131,7 +132,7 @@ module.exports = function (results, data) {
 
       const containsSuppressedMessages =
         result.suppressedMessages && result.suppressedMessages.length > 0;
-      const messages = containsSuppressedMessages
+      const messages = containsSuppressedMessages && !ignoreSuppressed
         ? [...result.messages, ...result.suppressedMessages]
         : result.messages;
 
@@ -195,7 +196,7 @@ module.exports = function (results, data) {
               sarifRepresentation.ruleIndex = sarifRuleIndices[message.ruleId];
             }
 
-            if (containsSuppressedMessages) {
+            if (containsSuppressedMessages && !ignoreSuppressed) {
               sarifRepresentation.suppressions = message.suppressions
                 ? message.suppressions.map((suppression) => {
                     return {


### PR DESCRIPTION
Fixes #80, this allows suppressed messages to be ignored when creating the SARIF file by setting `SARIF_ESLINT_IGNORE_SUPPRESSED` to `true`.