### PR TITLE
Ensure uniqueness in suppressions

### DIFF
--- a/packages/eslint-formatter-sarif/sarif.js
+++ b/packages/eslint-formatter-sarif/sarif.js
@@ -198,13 +198,19 @@ module.exports = function (results, data) {
             }
 
             if (containsSuppressedMessages && !ignoreSuppressed) {
+              const uniqueSuppressions = new Set();
               sarifRepresentation.suppressions = message.suppressions
-                ? message.suppressions.map((suppression) => {
-                    return {
-                      kind: suppression.kind === 'directive' ? 'inSource' : 'external',
-                      justification: suppression.justification,
-                    };
-                  })
+                ? message.suppressions.reduce((acc, suppression) => {
+                    const suppressionKey = `${suppression.kind}:${suppression.justification}`;
+                    if (!uniqueSuppressions.has(suppressionKey)) {
+                      uniqueSuppressions.add(suppressionKey);
+                      acc.push({
+                        kind: suppression.kind === 'directive' ? 'inSource' : 'external',
+                        justification: suppression.justification,
+                      });
+                    }
+                    return acc;
+                  }, [])
                 : [];
             }
           } else {

--- a/packages/eslint-formatter-sarif/sarif.js
+++ b/packages/eslint-formatter-sarif/sarif.js
@@ -199,19 +199,20 @@ module.exports = function (results, data) {
 
             if (containsSuppressedMessages && !ignoreSuppressed) {
               const uniqueSuppressions = new Set();
-              sarifRepresentation.suppressions = message.suppressions
-                ? message.suppressions.reduce((acc, suppression) => {
-                    const suppressionKey = `${suppression.kind}:${suppression.justification}`;
-                    if (!uniqueSuppressions.has(suppressionKey)) {
-                      uniqueSuppressions.add(suppressionKey);
-                      acc.push({
-                        kind: suppression.kind === 'directive' ? 'inSource' : 'external',
-                        justification: suppression.justification,
-                      });
-                    }
-                    return acc;
-                  }, [])
-                : [];
+              const suppressionsList = [];
+              if (message.suppressions) {
+                for (const suppression of message.suppressions) {
+                  const suppressionKey = `${suppression.kind}:${suppression.justification}`;
+                  if (!uniqueSuppressions.has(suppressionKey)) {
+                    uniqueSuppressions.add(suppressionKey);
+                    suppressionsList.push({
+                      kind: suppression.kind === 'directive' ? 'inSource' : 'external',
+                      justification: suppression.justification,
+                    });
+                  }
+                }
+              }
+              sarifRepresentation.suppressions = suppressionsList;
             }
           } else {
             // ESLint produces a message with no ruleId when it encounters an internal


### PR DESCRIPTION
This PR addresses an issue with duplicate items in the `suppressions` array, which was causing complaints from `upload-sarif`. By ensuring uniqueness in the `suppressions` array, we prevent duplicate items from being pushed. This improves the reliability of the SARIF upload process and resolves the issue reported by `upload-sarif`.

Changes made include implementing a mechanism to enforce uniqueness in the `suppressions` array, ensuring that each item is added only once.

close #86